### PR TITLE
including pandas as pd for subsequent code

### DIFF
--- a/example/sample_classification_with_augmentation.ipynb
+++ b/example/sample_classification_with_augmentation.ipynb
@@ -30,6 +30,7 @@
         "import random\n",
         "import numpy as np\n",
         "import tensorflow as tf\n",
+        "import pandas as pd\n",
         "from tensorflow.keras.optimizers import Adam\n",
         "from tensorflow.keras.applications import VGG19\n",
         "from tensorflow.keras.utils import to_categorical, plot_model\n",


### PR DESCRIPTION
the code fails without including the import pandas as pd line in the first block (at least for me). pd is referred to later in the 7th block around line 60.